### PR TITLE
Pause ingress secrets when issues are encountered

### DIFF
--- a/controllers/ingresssecret_controller.go
+++ b/controllers/ingresssecret_controller.go
@@ -251,7 +251,10 @@ func (r *IngressSecretReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 							return ctrl.Result{}, nil
 						}
 						if secretCert.NotAfter.After(*bulkCertificate.NotAfter) {
-							opLog.Info(fmt.Sprintf("Certificate has changed, old expiry is %v, new expiry is %v. Updating certificate in Fastly", secretCert.NotAfter, bulkCertificate.NotAfter))
+							opLog.Info(fmt.Sprintf("Certificate has changed, old expiry is %v, new expiry is %v. Updating certificate in Fastly",
+								secretCert.NotAfter,
+								bulkCertificate.NotAfter,
+							))
 							err = r.updateCertificate(ctx, ingressSecret, bulkCertificateIDAnnotation)
 							if err != nil {
 								errMsg := fmt.Sprintf("Certificate failed to update in Fastly, error was: %v", err)
@@ -333,7 +336,10 @@ func (r *IngressSecretReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 							return ctrl.Result{}, nil
 						}
 						if secretCert.NotAfter.After(*bulkCertificate.NotAfter) {
-							opLog.Info(fmt.Sprintf("Certificate has changed, old expiry is %v, new expiry is %v. Updating certificate in Fastly", secretCert.NotAfter, bulkCertificate.NotAfter))
+							opLog.Info(fmt.Sprintf("Certificate has changed, old expiry is %v, new expiry is %v. Updating certificate in Fastly",
+								secretCert.NotAfter,
+								bulkCertificate.NotAfter,
+							))
 							err = r.updateCertificate(ctx, ingressSecret, bulkCertificateIDAnnotation)
 							if err != nil {
 								errMsg := fmt.Sprintf("Certificate failed to update in Fastly, error was: %v", err)


### PR DESCRIPTION
This PR adds the patching of paused status when any errors are hit to more conditions.

This allows the controller to keep running properly while logging any errors encountered in the ingress secret resource, and setting it to a paused state.