### PR TITLE
correct Certificate has changed message

### DIFF
--- a/controllers/ingresssecret_controller.go
+++ b/controllers/ingresssecret_controller.go
@@ -281,8 +281,8 @@ func (r *IngressSecretReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 						}
 						if secretCert.NotAfter.After(*bulkCertificate.NotAfter) {
 							opLog.Info(fmt.Sprintf("Certificate has changed, old expiry is %v, new expiry is %v. Updating certificate in Fastly",
-								secretCert.NotAfter,
 								bulkCertificate.NotAfter,
+								secretCert.NotAfter,
 							))
 							err = r.updateCertificate(ctx, ingressSecret, bulkCertificateIDAnnotation)
 							if err != nil {


### PR DESCRIPTION
before it showed messages like:

```
Certificate has changed, old expiry is 2022-08-11 12:59:35 +0000 UTC, new expiry is 2022-06-12 13:58:55 +0000 UTC. Updating certificate in Fastly
```
which was rather confusing :)